### PR TITLE
Fix empty response on fetch

### DIFF
--- a/ErpFetch.js
+++ b/ErpFetch.js
@@ -75,7 +75,12 @@ export class ErpFetch {
         } else if (responseType === 'arrayBuffer') {
           return response.arrayBuffer()
         } else if (responseType === 'json') {
-          return response.json()
+          if (response.status === 204) {
+            // empty response
+            return null;
+          } else {
+            return response.json();
+          }
         } else {
           return response;
         }


### PR DESCRIPTION
Check the status code (204 means no content) and the content type to know if we can safely call 'response.json()'